### PR TITLE
fixing full profile field names

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -83,8 +83,8 @@ Strategy.prototype._convertScopeToUserProfileFields = function(scope, profileFie
     ],
     'r_emailaddress':   ['email-address'],
     'r_fullprofile':   [
-      'last-modified-timstamp',
-      'first-proposal-comments',
+      'last-modified-timestamp',
+      'proposal-comments',
       'associations',
       'interests',
       'publications',
@@ -104,7 +104,7 @@ Strategy.prototype._convertScopeToUserProfileFields = function(scope, profileFie
       'job-bookmarks',
       'suggestions',
       'date-of-birth',
-      'member-url-resources:(name, url)',
+      'member-url-resources:(name,url)',
       'related-profile-views',
       'honors-awards'
     ]

--- a/test/strategy.tests.js
+++ b/test/strategy.tests.js
@@ -176,8 +176,8 @@ describe.only('LinkedIn Strategy', function () {
           'site-standard-profile-request,'+
           'api-standard-profile-request:(headers,url),'+
           'public-profile-url,'+
-          'last-modified-timstamp,'+
-          'first-proposal-comments,'+
+          'last-modified-timestamp,'+
+          'proposal-comments,'+
           'associations,'+
           'interests,'+ 
           'publications,'+
@@ -197,7 +197,7 @@ describe.only('LinkedIn Strategy', function () {
           'job-bookmarks,'+
           'suggestions,'+
           'date-of-birth,'+
-          'member-url-resources:(name, url),'+
+          'member-url-resources:(name,url),'+
           'related-profile-views,'+
           'honors-awards)');
          done();


### PR DESCRIPTION
I had errors when using this library, they were occurring when it was getting the user's full profile:
- `Unknown field {last-modified-timstamp} in resource {Person}`
- `Unknown field {first-proposal-comments} in resource {Person}`
- `Unknown field {_url} in resource {MemberUrl}`

After checking the http://developer.linkedin.com/documents/profile-fields I've changed the names for profile fields according to it and it should work now.
