### PR TITLE
Updated dependencies to enable auto 'state' param handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ app.get('/auth/linkedin/callback', passport.authenticate('linkedin', {
 
 See [this](http://developer.linkedin.com/) for details on LinkedIn API.
 
+## Auto-handle `state` param
+
+The `state` param is used to prevent CSRF attacks, and is [required by the LinkedIn API](https://developer.linkedin.com/documents/authentication). You can ask Passport to handle the sending and validating of the `state` parameter by passing `state: true` as an option to the strategy:
+
+~~~javascript
+var LinkedInStrategy = require('passport-linkedin-oauth2').Strategy;
+
+passport.use(new LinkedInStrategy({
+        clientID: LINKEDIN_KEY,
+        clientSecret: LINKEDIN_SECRET,
+        callbackURL: "http://127.0.0.1:3000/auth/linkedin/callback"
+        scope: ['r_emailaddress', 'r_basicprofile'],
+        state: true
+      }, function(accessToken, refreshToken, profile, done) {
+        // asynchronous verification, for effect...
+        process.nextTick(function () {
+          // To keep the example simple, the user's Google profile is returned to
+          // represent the logged-in user.  In a typical application, you would want
+          // to associate the Google account with a user record in your database,
+          // and return that user instead.
+          return done(null, profile);
+        });
+        }
+    ));
+~~~
+
+and then authenticate as:
+
+~~~javascript
+app.get('/auth/linkedin',
+                passport.authenticate('linkedin'),
+      function(req, res){
+        // The request will be redirected to LinkedIn for authentication, so this
+        // function will not be called.
+      });
+
+~~~
+
 ## License
 
-MIT - 2013 - AUTH0
+MIT - 2014 - AUTH0

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -1,7 +1,7 @@
 var util = require('util'),
    _ = require('underscore')
-  , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
-  , InternalOAuthError = require('passport-oauth').InternalOAuthError;
+  , OAuth2Strategy = require('passport-oauth2')
+  , InternalOAuthError = require('passport-oauth2').InternalOAuthError;
 
 function Strategy(options, verify) {
   options = options || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-linkedin-oauth2",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Passport for LinkedIn Oauth2",
   "main": "./lib",
   "repository": "https://github.com/auth0/passport-linkedin-oauth2",
@@ -32,11 +32,15 @@
     {
       "name": "Jose Romaniello",
       "email": "jfromaniello@gmail.com"
+    },
+    {
+      "name": "Tom Spencer",
+      "email": "fiznool@gmail.com"
     }
   ],
   "license": "MIT",
   "dependencies": {
-    "passport-oauth": "~0.1.14",
-    "underscore": "~1.5.2"
+    "passport-oauth2": "^1.1.2",
+    "underscore": "^1.7.0"
   }
 }


### PR DESCRIPTION
The latest version of passport-oauth2 allows the `state` param to be created and validated transparently. Updating the dependency here allows us to use this by setting `state: true` on the strategy options.
