### PR TITLE
Fixed profile photo parsing

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -42,7 +42,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile.emails = [{ value: json.emailAddress }];
       profile.photos = [];
       if (json.pictureUrl) {
-          profile.photos.push(json.pictureUrl);
+          profile.photos.push({ value: json.pictureUrl });
       }
       profile._raw = body;
       profile._json = json;


### PR DESCRIPTION
Photos should follow the format as specified in the [passport profile guide](http://passportjs.org/guide/profile/).

This PR fixes, to mirror how the [passport-facebook](https://github.com/jaredhanson/passport-facebook/blob/f52fcf8bafc4aa423d20623b355af5388e413abb/lib/profile.js#L33) module works.