### PR TITLE
Auth sometimes fails fetching profile for r_basicprofile and anything that requests public-profile-url

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -25,8 +25,22 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   //LinkedIn uses a custom name for the access_token parameter
   this._oauth2.setAccessTokenName("oauth2_access_token");
 
+  var strategy = this;
   this._oauth2.get(this.profileUrl, accessToken, function (err, body, res) {
-    if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
+    if (err) {
+        if(!strategy.profileUrl.match('public-profile-url')) {
+            return done(new InternalOAuthError('failed to fetch user profile', err));
+        } else { // Retry without requesting the field 'public-profile-url' which errors out if the user has disabled their public profile
+            strategy.profileUrl = strategy.profileUrl.replace('public-profile-url','');
+            strategy.profileUrl = strategy.profileUrl.replace(',,',',');
+            strategy.profileUrl = strategy.profileUrl.replace('(,','(');
+            strategy.profileUrl = strategy.profileUrl.replace(',)',')');
+
+            return strategy.userProfile(accessToken, function(err, profile) {
+                return done(err, profile);
+            });
+        }
+    }
 
     try {
       var json = JSON.parse(body);


### PR DESCRIPTION
The linkedin API https://api.linkedin.com/v1/people/~:(public-profile-url) fails with an HTTP 500 error if the user has set privacy settings to not publish their public profile.  If this failure happens, then re-request the profile, with that element removed from the request, so that it can succeed.

Without this change, users who have restricted their public profile cannot log in via this module.
