### PR TITLE
Add handling of custom LinkedIn error codes

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -20,6 +20,24 @@ function Strategy(options, verify) {
 
 util.inherits(Strategy, OAuth2Strategy);
 
+/**
+ * Authenticate request override to handle LinkedIn user triggered error codes
+ *
+ * @param {http.IncomingMessage} req
+ * @param {object} options
+ */
+Strategy.prototype.authenticate = function(req, options) {
+  if (req.query && req.query.error) {
+    if (req.query.error === 'user_cancelled_login' || req.query.error === 'user_cancelled_authorize') {
+      return this.fail({ message: req.query.error_description });
+    } else {
+      return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
+    }
+  }
+
+  OAuth2Strategy.prototype.authenticate.call(this, req, options);
+};
+
 Strategy.prototype.userProfile = function(accessToken, done) {
 
   //LinkedIn uses a custom name for the access_token parameter


### PR DESCRIPTION
Hello,

as seen on the LinkedIn specification : https://developer.linkedin.com/docs/oauth2

In the chapter "Application is rejected".

We can see that there are 2 custom error code sent by LinkedIn.
These are causing passportjs to crash, whereas we can handle this with the failureRedirect and show an error message to the user.

Here is an attempt at fixing it.

Best regards,