### PR TITLE
Fix for r_basicprofile Scope and Handling OpenID/Profile Scopes in passport-linkedin-oauth2

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -13,6 +13,10 @@ function Strategy(options, verify) {
     options.tokenURL || 'https://www.linkedin.com/oauth/v2/accessToken';
   options.scope = options.scope || ['profile', 'email', 'openid'];
 
+  if (options.scope.includes('r_basicprofile')) {
+    profileUrl = 'https://api.linkedin.com/v2/me';
+  }
+  
   //By default we want data in JSON
   options.customHeaders = options.customHeaders || { 'x-li-format': 'json' };
 


### PR DESCRIPTION
### Description

This pull request addresses an issue related to the `r_basicprofile` scope in the `passport-linkedin-oauth2` repository. The problem arises when the "Community Management API" product is enabled, leading to the unavailability of the `openid` or `profile` scopes. Consequently, the `https://api.linkedin.com/v2/userinfo` API throws an error under these conditions.

#### Changes Made

- Added a fix to address the issue caused by the unavailability of `openid` or `profile` scopes when the "Community Management API" product is enabled.
- Implemented a check for the presence of the `r_basicprofile` scope. If this scope is added, the profile is now fetched from the `https://api.linkedin.com/v2/me` endpoint.

### Context

The LinkedIn API behavior change, particularly when certain products like "Community Management API" are enabled, has been causing errors due to missing scopes. This pull request ensures a robust handling mechanism, ensuring a smooth experience even under such circumstances.

### How to Test

1. Enable the "Community Management API" product in your LinkedIn Developer account.
2. Attempt authentication with the affected scopes (`openid` or `profile`) using the `passport-linkedin-oauth2` strategy.
3. Verify that the error no longer occurs and that the profile is correctly fetched when the `r_basicprofile` scope is present.

### Additional Notes

Please review and merge this pull request at your earliest convenience. If there are any concerns or questions, feel free to reach out. This fix ensures compatibility with the latest LinkedIn API changes, providing a seamless experience for users utilizing the "Community Management API" product.

Thank you for your time and consideration.

Best regards,
Vilas Shetkar