### PR TITLE
feat: Normalize 'emails', 'photos' and 'name' in 'profile'

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -76,6 +76,9 @@ function parseProfile(body) {
     familyName: json.family_name,
     displayName: `${json.given_name} ${json.family_name}`,
     picture: json.picture,
+    emails: [{ value: json.email, verified: json.email_verified }],
+    photos: [{ value: json.picture }],
+    name: { givenName: json.given_name, familyName: json.family_name },
     _raw: body,
     _json: json,
   };


### PR DESCRIPTION
Use same structure from other providers according to [Passport.js documentation](https://www.passportjs.org/reference/normalized-profile):

- 'profile.emails' => Array of Objects with 'value' and 'verified'
- 'profile.photos' => Array of Objects with 'value'
- 'profile.name' => Object with 'givenName' and 'familyName'